### PR TITLE
feat: Add support for including partials in mustache templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<changelog-lib>1.159.0</changelog-lib>
+		<changelog-lib>1.160.0</changelog-lib>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/se/bjurr/gitchangelog/plugin/GitChangelogMojo.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/GitChangelogMojo.java
@@ -49,6 +49,12 @@ public class GitChangelogMojo extends AbstractMojo {
   @Parameter(property = "templateContent", required = false)
   private String templateContent;
 
+  @Parameter(property = "templateBaseDir", required = false)
+  private String templateBaseDir;
+
+  @Parameter(property = "templateSuffix", required = false)
+  private String templateSuffix;
+
   @Parameter(property = "file", required = false)
   private File file;
 
@@ -181,6 +187,12 @@ public class GitChangelogMojo extends AbstractMojo {
       }
       if (this.isSupplied(this.templateContent)) {
         builder.withTemplateContent(this.templateContent);
+      }
+      if (this.isSupplied(this.templateBaseDir)) {
+        builder.withTemplateBaseDir(templateBaseDir);
+      }
+      if (this.isSupplied(this.templateSuffix)) {
+        builder.withTemplateSuffix(templateSuffix);
       }
       if (this.isSupplied(this.fromCommit)) {
         builder.withFromCommit(this.fromCommit);


### PR DESCRIPTION
This MR adds support for partials in the Maven plugin:

- Update `git-changelog-lib` to 1.160.0
- Add possibility to set`templateBaseDir` and  `templateSuffix` configuration (required to use partials in mustache templates)

ref https://github.com/tomasbjerre/git-changelog-lib/pull/109
