### PR TITLE
Add custom property for Jira server base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Or in `pom.xml`:
           <semanticMajorVersionPattern>^[Bb]reaking</semanticMajorVersionPattern>
           <semanticMinorVersionPattern>[Ff]eature</semanticMinorVersionPattern>
           <semanticPatchVersionPattern>[Ff]ix</semanticPatchVersionPattern>
+
+          <jiraBasePath>https://my-company.atlassian.net/rest/api/latest</jiraBasePath>
         </configuration>
        </execution>
       </executions>

--- a/src/main/java/se/bjurr/gitchangelog/plugin/GitChangelogMojo.java
+++ b/src/main/java/se/bjurr/gitchangelog/plugin/GitChangelogMojo.java
@@ -149,6 +149,9 @@ public class GitChangelogMojo extends AbstractMojo {
   @Parameter(property = "jiraBearer", required = false)
   private String jiraBearer;
 
+  @Parameter(property = "jiraBasePath", required = false)
+  private String jiraBasePath;
+
   @Parameter(property = "redmineIssuePattern", required = false)
   private String redmineIssuePattern;
 
@@ -338,7 +341,9 @@ public class GitChangelogMojo extends AbstractMojo {
       if (this.isSupplied(this.jiraIssuePattern)) {
         builder.withJiraIssuePattern(this.jiraIssuePattern);
       }
-      if (this.isSupplied(this.jiraServer)) {
+      if (this.isSupplied(this.jiraBasePath)) {
+        builder.withJiraServer(this.jiraBasePath);
+      } else if (this.isSupplied(this.jiraServer)) {
         builder.withJiraServer(this.jiraServer);
       }
       if (this.isSupplied(this.jiraBearer)) {


### PR DESCRIPTION
Related to #63

DONT Merge just a SHOW-Case for Github-Codespaces
Add custom property for Jira server base path.

* Add `jiraBasePath` property to `GitChangelogMojo.java`.
* Update `execute` method in `GitChangelogMojo.java` to use `jiraBasePath` if set.
* Update `builder` in `GitChangelogMojo.java` to use `jiraBasePath` if set.
* Update `README.md` to document the new `jiraBasePath` property.
* Delete the added section of the #### Jira Configuration and add an example like `<jiraBasePath>https://my-company.atlassian.net/rest/api/latest</jiraBasePath>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomasbjerre/git-changelog-maven-plugin/issues/63?shareId=e448332d-2438-4e89-a082-98cd28d0eccc).